### PR TITLE
Make the TypeName for a WildcardType return correctly in cases of no upper bound.

### DIFF
--- a/src/main/java/com/squareup/javapoet/WildcardTypeName.java
+++ b/src/main/java/com/squareup/javapoet/WildcardTypeName.java
@@ -22,6 +22,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import javax.lang.model.type.TypeMirror;
+
 import static com.squareup.javapoet.Util.checkArgument;
 
 public final class WildcardTypeName extends TypeName {
@@ -89,9 +91,17 @@ public final class WildcardTypeName extends TypeName {
   }
 
   public static TypeName get(javax.lang.model.type.WildcardType mirror) {
-    TypeName extendsBound = TypeName.get(mirror.getExtendsBound());
-    TypeName superBound = TypeName.get(mirror.getSuperBound());
-    return superBound != null ? supertypeOf(superBound) : subtypeOf(extendsBound);
+    TypeMirror extendsBound = mirror.getExtendsBound();
+    if (extendsBound == null) {
+      TypeMirror superBound = mirror.getSuperBound();
+      if (superBound == null) {
+        return subtypeOf(Object.class);
+      } else {
+        return supertypeOf(TypeName.get(superBound));
+      }
+    } else {
+      return subtypeOf(TypeName.get(extendsBound));
+    }
   }
 
   public static TypeName get(WildcardType wildcardName) {


### PR DESCRIPTION
Make the TypeName for a WildcardType return correctly in cases of no upper bound.
-------------
Created by MOE: http://code.google.com/p/moe-java
MOE_MIGRATED_REVID=86225806